### PR TITLE
Clarify example config

### DIFF
--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -185,7 +185,7 @@ stellar-core loads `./stellar-core.cfg`, but you can specify a different file to
 
 `$ stellar-core --conf betterfile.cfg` 
 
-The [example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg) is not a real configuration and is the most important one: it documents all possible configuration elements as well as default values.
+The [example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg) is **not a real configuration** and should only be used as a reference guide: it documents all possible configuration elements as well as default values.
 
 Here is an [example test network config](https://github.com/stellar/docker-stellar-core-horizon/blob/master/testnet/core/etc/stellar-core.cfg) for connecting to the test network.
 


### PR DESCRIPTION
In answering [this question](https://stellar.stackexchange.com/questions/731/running-into-an-invalid-quorum-set-error-when-running-stellar-core) on Stack Exchange, I realized it may not be entirely obvious that:
a) the example config should not be used verbatim and
b) the example config is more of a reference than an example.

Hopefully this rewording creates more clarity for new stellar-core users.